### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build main branch
+permissions:
+  contents: read
 
 on:
   push:
@@ -79,6 +81,8 @@ jobs:
     concurrency: ci-${{ github.ref }}
     needs: [build, prepare] # The second job must depend on the first one to complete before running and uses ubuntu-latest instead of windows.
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Set Version
         env:


### PR DESCRIPTION
Potential fix for [https://github.com/nomailme/certificate-info/security/code-scanning/10](https://github.com/nomailme/certificate-info/security/code-scanning/10)

In general, the fix is to add an explicit `permissions` block to the workflow, preferably at the top level so that all jobs inherit a minimal set of permissions, and then override it for specific jobs that require additional scopes. This constrains the `GITHUB_TOKEN` according to the principle of least privilege and documents the intended usage.

In this specific workflow, we can add a root-level `permissions:` block with `contents: read` to cover `prepare` and `build`, which only need to read the repository to run `actions/checkout` and use external actions. The `release` job needs to create a GitHub release and tag via `ncipollo/release-action@v1`, so we should override its permissions with `contents: write`. This leaves the rest of the workflow logic unchanged while making token scopes explicit. Concretely:
- Insert a `permissions:` block after `name: Build main branch` (before `on:`).
- Add a `permissions:` block inside the `release` job that sets `contents: write`.

No additional imports, methods, or external libraries are required, since this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
